### PR TITLE
Fix #18 : registry file 기록시간 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,6 @@ services:
     networks:
       - elk
     depends_on:
-      - nginx
       - filebeat
     environment:
       TZ: Asia/Seoul
@@ -131,6 +130,8 @@ services:
       - "80:80"
     networks:
       - elk
+    depends_on:
+      - application
     environment:
       TZ: Asia/Seoul
 networks:

--- a/filebeat/config/filebeat.yml
+++ b/filebeat/config/filebeat.yml
@@ -17,6 +17,16 @@ filebeat.inputs:
     - add_tags:
         tags: [ app_log ]
         target: "log_type"
+  # state options
+  # file handler의 timeout 설정.
+  # 설정한 시간 이상으로 파일 읽기 작업을 하지 않으면 핸들러 닫는다.
+  close_inactive: 24h
+  #최종 변경일시로 읽기 대상 제외 지정.
+  ignore_older: 24h
+  #clean_inactive에 설정된 시간보다 수정된 시간이 오래되어있으면 registry에서 삭제
+  clean_inactive: 72h
+  #clean_removed : 디스크에서 찾을 수 없는 파일의 정보를 registry에서 삭제.
+  clean_removed: true
 
 - type: filestream
   enabled: true
@@ -38,16 +48,10 @@ filebeat.inputs:
         tags: [ nginx_log ]
         target: "log_type"
 
-  # state options
-  # file handler의 timeout 설정.
-  # 설정한 시간 이상으로 파일 읽기 작업을 하지 않으면 핸들러 닫는다.
-  close_inactive: 2m
 
-  #최종 변경일시로 읽기 대상 제외 지정.
-  ignore_older: 1m
-  #clean_inactive에 설정된 시간보다 수정된 시간이 오래되어있으면 registry에서 삭제
-  clean_inactive: 1m
-  #clean_removed : 디스크에서 찾을 수 없는 파일의 정보를 registry에서 삭제.
+  close_inactive: 24h
+  ignore_older: 24h
+  clean_inactive: 72h
   clean_removed: true
 
 - type: container
@@ -67,6 +71,11 @@ filebeat.inputs:
     - add_tags:
         tags: [ container_log ]
         target: "log_type"
+  close_inactive: 24h
+  ignore_older: 24h
+  clean_inactive: 72h
+  clean_removed: true
+
 processors:
   - add_locale: ~
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39519869/180714084-793c52ff-9bc9-4a0b-8d1e-0d1c21224398.png)

docker restart시에도 이전 log들이 보내지지 않음을 확인.

- 원인
- clean_inactive 시간이 너무 짧았다. -> registry file이 inactive_file에 대한 정보를 저장해놓는 시간.
- registry file은 volume에 잘 저장되고 있었음.
- 차후 실제 프로젝트에서는 clean_inactive를 lotation 기간에 맞춰 정해줘야함.